### PR TITLE
Disable travis notification in ##crawl-dev :)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ notifications:
         on_failure: always
 #        recipients:
 #          - crawl-ref-commits@lists.sourceforge.net
-    irc:
-        channels: "chat.freenode.net##crawl-dev"
-        on_success: change
-        on_failure: always
-        use_notice: true
-        template:
-            - "%{message} (%{branch} - %{commit} #%{build_number} : %{author}): %{build_url}"
+#    irc:
+#        channels: "chat.freenode.net##crawl-dev"
+#        on_success: change
+#        on_failure: always
+#        use_notice: true
+#        template:
+#            - "%{message} (%{branch} - %{commit} #%{build_number} : %{author}): %{build_url}"


### PR DESCRIPTION
travis is showing up in ##crawl-dev with build failures from this fork, thanks in advance. (First version of this note / commit message sounded accidentally sarcastic, completely unintentional, sorry!)